### PR TITLE
Add note that don't need to apply EC patch if device already `Device (EC)`

### DIFF
--- a/Laptops/laptop-ec.md
+++ b/Laptops/laptop-ec.md
@@ -19,6 +19,9 @@ When this happens you need to figure out which is the main and which is not, it'
 
 Note that only the main EC needs renaming, if you only have one `PNP0C09` then it is automatically your main regardless of properties.
 
+> What happens if `PNP0C09` already named `Device (EC)`
+
+This mean you don't have to apply EC patch!
 
 # Applying your EC patch
 


### PR DESCRIPTION
I've trying to follow this guide for my new Thinkpad T480, my device show up is already `Device (EC)`. I've confused at is not mention in the guide. After digging some other Clover EFI prebuilt and discuss in Discord, I've found that is mean I don't have to apply the patch.
Hope add this note to the guide will help other.